### PR TITLE
Fix local_address function in utility.py

### DIFF
--- a/src/core/utility.py
+++ b/src/core/utility.py
@@ -92,9 +92,9 @@ def local_address():
         ifconfig = ifconfig.split("\n")
         for idx in xrange(len(ifconfig)):
             if state.listener in ifconfig[idx]:
-                adapter = ifconfig[idx+1].split()[1][5:]
+                adapter = ifconfig[idx+1].split()[1] # removed '[5:]' as it was stripping off the first two octets
     else:
-        adapter = ifconfig.split("\n")[1].split()[1][5:]
+        adapter = ifconfig.split("\n")[1].split()[1] # removed '[5:]' as it was stripping off the first two octets
 
     if not adapter:
         Msg("Unable to find adapter %s" % state.listener, LOG.ERROR)


### PR DESCRIPTION
#In Line 95, I changed
"adapter = ifconfig[idx+1].split()[1][5:]" # to just
"adapter = ifconfig[idx+1].split()[1]"
#removing [5:] as it was stripping off the first two octets
#In Line 97, I changed
adapter = ifconfig.split("\n")[1].split()[1][5:] # to just
adapter = ifconfig.split("\n")[1].split()[1]